### PR TITLE
Add notionURL field to hyperlink to  a notion page

### DIFF
--- a/src/components/CommonCard.astro
+++ b/src/components/CommonCard.astro
@@ -8,12 +8,13 @@ interface Props {
 }
 
 const { post } = Astro.props;
+const postUrl = post.data.notionUrl || `/posts/${post.slug}/`;
 ---
 
 <div
   class="relative overflow-hidden rounded-xl bg-white transition-transform duration-500 hover:-translate-y-1 hover:scale-105 dark:bg-neutral-900"
 >
-  <a href={`/posts/${post.slug}/`} class="block">
+  <a href={postUrl} class="block" target={post.data.notionUrl ? "_blank" : undefined}>
     <OptimizedCover src={post.data.cover} alt={post.data.coverAlt} />
     <div class="absolute bottom-0 end-0 start-0 bg-gradient-to-t p-5 md:p-6">
       <div class="mt-16 flex items-center gap-4 text-xs text-white">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,6 +11,7 @@ const posts = defineCollection({
     category: z.array(z.string()),
     tags: z.array(z.string()),
     author: z.string(),
+    notionUrl: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
# What does this PR do?

Tiny PR to be able to hyperlink to a notionURL. Just requires `notionURL` field in the post metadata and gtg. 